### PR TITLE
Various bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 *~
 .DS_Store
 build
-*.xcodeproj/*.pbxuser
-*.xcodeproj/*.mode1
-*.xcodeproj/*.mode1v3
-*.xcodeproj/xcuserdata/
-*.xcodeproj/project.xcworkspace/xcuserdata/
+*.mode1
+*.mode1v3
+*.mode2v3
+*.perspective
+*.perspectivev3
+*.pbxuser
+*.xcuserdatad
+*.xcworkspacedata

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -679,8 +679,18 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 		backgroundRect.size.height = backgroundRect.size.height + MAX_BOUNCE_DISTANCE;
 	}
 	
-	CGFloat minimumHeight = rect.size.height;
-	CGFloat actualHeight = [_gridData cellSize].height * ([_gridData numberOfItems] / [_gridData numberOfItemsPerRow] + 1);
+	CGFloat minimumHeight = rect.size.height, 
+		actualHeight = 0;
+		
+	if (([_gridData numberOfItems] == 0) || ([_gridData numberOfItemsPerRow] == 0)) {
+	
+		actualHeight = [_gridData cellSize].height;
+	
+	} else {
+	
+		actualHeight = [_gridData cellSize].height * ([_gridData numberOfItems] / [_gridData numberOfItemsPerRow] + 1);
+		
+	}
 	for (; actualHeight < minimumHeight; actualHeight += [_gridData cellSize].height) {
 	}
 	backgroundRect.size.height = actualHeight;

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -1239,12 +1239,25 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 {
 	if ( [hitView isKindOfClass: [UIControl class]] )
 		return ( NO );
+
+
+//	Simply querying the superview will not work if the hit view is a subview of the contentView, e.g. its superview is a plain UIView *inside* a cell
 	
 	if ( [[hitView superview] isKindOfClass: [AQGridViewCell class]] )
 		return ( YES );
 	
 	if ( [hitView isKindOfClass: [AQGridViewCell class]] )
 		return ( YES );
+	
+	CGPoint hitCenter = [self convertPoint:[hitView center] fromView:hitView];
+				
+	for ( AQGridViewCell *aCell in [[[self visibleCells] copy] autorelease])
+	{
+	
+		if ( CGRectContainsPoint( aCell.frame, hitCenter ) )
+		return ( YES );
+	
+	}
 	
 	return ( NO );
 }


### PR DESCRIPTION
Please kindly review these commits:

7490f026bc1916160c4c174654dffb45e3dd441c
Fixes arithmetic error when there are zero items thus triggering a division-by-zero error.

66d5fb784c7f92322ce10fbbb521334d92273e2a
Ignores more Xcode noise

68e6de37e11d28dfedc9d2e15ca9e8cf3fce4564
Fixes circumstance where (as tested on the shiny iOS SDK v.redacted):

```
an AQGridViewCell
-> an UIImageView or other view (hit test passes)
-> an UIView (hit test passes)
  -> a subclassed UIView (hit test does not pass, nor does the touch event “populate” upwards)
```

which interferes with one of the use cases, where a subclassed `UIView` is responsible for drawing an inner shadow and has the same size of the content view.
