### PR TITLE
Bugfix in the AQGridView > setContentSize: method

### DIFF
--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -509,12 +509,16 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	
 	if (self.gridFooterView)
 	{
+		// Get the status bar frame and convert it to the appropriate coordinate system
+		CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+		statusBarFrame = [self convertRect:statusBarFrame fromView:nil];
+		
 	    // In-call status bar influences footer position
-	    CGFloat statusHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame) - 20;
+	    CGFloat statusHeight = CGRectGetHeight(statusBarFrame) - 20;
 
 	    CGFloat footerHeight = CGRectGetHeight(self.gridFooterView.bounds);
 	    CGFloat minimumHeight = statusHeight + CGRectGetHeight(self.bounds) + footerHeight;
-	    if (newSize.height < footerHeight + minimumHeight)
+	    if (newSize.height < minimumHeight)
 	        newSize.height = minimumHeight;
 	}
 	


### PR DESCRIPTION
Hi Jim,

The statusBarFrame height is 20.0 in portrait mode and 1024.0 in landscape mode, so it must be converted to the appropriate coordinate system before being used to compute the minimum height.

Comments are in the commit message.

Hope this helps,
Thomas.
