### PR TITLE
AQGridViewCell’s background and content views configurable via Interface Builder; exception is logged and re-thrown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 *~
 .DS_Store
 build
-*.xcodeproj/*.pbxuser
-*.xcodeproj/*.mode1
-*.xcodeproj/*.mode1v3
-*.xcodeproj/xcuserdata/
-*.xcodeproj/project.xcworkspace/xcuserdata/
+*.mode1
+*.mode1v3
+*.mode2v3
+*.perspective
+*.perspectivev3
+*.pbxuser
+*.xcuserdatad
+*.xcworkspacedata

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -679,8 +679,18 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 		backgroundRect.size.height = backgroundRect.size.height + MAX_BOUNCE_DISTANCE;
 	}
 	
-	CGFloat minimumHeight = rect.size.height;
-	CGFloat actualHeight = [_gridData cellSize].height * ([_gridData numberOfItems] / [_gridData numberOfItemsPerRow] + 1);
+	CGFloat minimumHeight = rect.size.height, 
+		actualHeight = 0;
+		
+	if (([_gridData numberOfItems] == 0) || ([_gridData numberOfItemsPerRow] == 0)) {
+	
+		actualHeight = [_gridData cellSize].height;
+	
+	} else {
+	
+		actualHeight = [_gridData cellSize].height * ([_gridData numberOfItems] / [_gridData numberOfItemsPerRow] + 1);
+		
+	}
 	for (; actualHeight < minimumHeight; actualHeight += [_gridData cellSize].height) {
 	}
 	backgroundRect.size.height = actualHeight;

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -1723,6 +1723,12 @@ passToSuper:
 			[self layoutAllCells];
 		}
 	}
+	@catch (NSException *exception) {
+
+		NSLog(@"Exception: %@", exception);
+		@throw exception;
+
+	}
 	@finally
 	{
 		[UIView setAnimationsEnabled: enableAnim];

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -1239,12 +1239,25 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 {
 	if ( [hitView isKindOfClass: [UIControl class]] )
 		return ( NO );
+
+
+//	Simply querying the superview will not work if the hit view is a subview of the contentView, e.g. its superview is a plain UIView *inside* a cell
 	
 	if ( [[hitView superview] isKindOfClass: [AQGridViewCell class]] )
 		return ( YES );
 	
 	if ( [hitView isKindOfClass: [AQGridViewCell class]] )
 		return ( YES );
+	
+	CGPoint hitCenter = [self convertPoint:[hitView center] fromView:hitView];
+				
+	for ( AQGridViewCell *aCell in [[[self visibleCells] copy] autorelease])
+	{
+	
+		if ( CGRectContainsPoint( aCell.frame, hitCenter ) )
+		return ( YES );
+	
+	}
 	
 	return ( NO );
 }

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -1769,6 +1769,7 @@ passToSuper:
 		NSLog(@"Exception: %@", exception);
 		@throw exception;
 
+	}
 	@finally
 	{
 		[UIView setAnimationsEnabled: enableAnim];

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -1591,7 +1591,6 @@ passToSuper:
 				
 				NSUInteger index=[shifted firstIndex];
 				while(index != NSNotFound){
-					NSLog(@"%i >= %i ?", index, [_visibleCells count]);
 					if (index >= [_visibleCells count]) {
 						[shifted removeIndex:index];
 					}					

--- a/Classes/AQGridViewCell.h
+++ b/Classes/AQGridViewCell.h
@@ -92,10 +92,10 @@ typedef enum {
 - (id) initWithFrame: (CGRect) frame reuseIdentifier: (NSString *) reuseIdentifier;
 
 // If you want to customize cells by simply adding additional views, you should add them to the content view so they will be positioned appropriately as the cell transitions into and out of editing mode.
-@property (nonatomic, readonly, retain) UIView * contentView;
+@property (nonatomic, readonly, retain) IBOutlet UIView * contentView;
 
 // default is nil. The background view will be added as a subview behind all other views
-@property (nonatomic, retain) UIView * backgroundView;
+@property (nonatomic, retain) IBOutlet UIView * backgroundView;
 
 // The 'selectedBackgroundView' will be added as a subview directly above the backgroundView if not nil, or behind all other views. It is added as a subview only when the cell is selected. Calling -setSelected:animated: will cause the 'selectedBackgroundView' to animate in and out with an alpha fade.
 @property (nonatomic, retain) UIView * selectedBackgroundView;

--- a/Classes/AQGridViewCell.m
+++ b/Classes/AQGridViewCell.m
@@ -316,6 +316,9 @@
 {
 	if ( (_cellFlags.usingDefaultSelectedBackgroundView == 1) && (_selectedBackgroundView == nil) )
 	{
+	
+		NSString * imageName;
+	
 #ifdef BUILTIN_IMAGES
 		unsigned char * pngBytes = AQGridSelection_png;
 		NSUInteger pngLength = AQGridSelection_png_len;
@@ -345,7 +348,7 @@
 		NSData *pngData = [NSData dataWithBytesNoCopy: pngBytes length: pngLength freeWhenDone: NO];
 		_selectedBackgroundView = [[UIImageView alloc] initWithImage: [UIImage imageWithData: pngData]];
 #else
-		NSString * imageName = @"AQGridSelection.png";
+		imageName = @"AQGridSelection.png";
 		switch ( _cellFlags.selectionStyle )
 		{
 			case AQGridViewCellSelectionStyleBlue:

--- a/Classes/AQGridViewCell.m
+++ b/Classes/AQGridViewCell.m
@@ -43,6 +43,7 @@
 @interface AQGridViewCell ()
 @property (nonatomic, retain) UIView * contentView;
 @property (nonatomic, copy) NSString * reuseIdentifier;
+
 @end
 
 @implementation AQGridViewCell
@@ -76,7 +77,7 @@
 
 - (void) awakeFromNib
 {
-    _cellFlags.usingDefaultSelectedBackgroundView = 1;
+	_cellFlags.usingDefaultSelectedBackgroundView = 1;
 	_cellFlags.separatorStyle = AQGridViewCellSeparatorStyleEmptySpace;
 	
 	if ( [CALayer instancesRespondToSelector: @selector(shadowPath)] )
@@ -85,7 +86,7 @@
 		_cellFlags.selectionStyle = AQGridViewCellSelectionStyleGray;
 	_selectionColorInfo = CFDictionaryCreateMutable( kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,  &kCFTypeDictionaryValueCallBacks );
 	self.backgroundColor = [UIColor whiteColor];
-    
+	    
     [super awakeFromNib];
 }
 
@@ -127,17 +128,31 @@
 
 - (UIView *) contentView
 {
-	if ( _contentView == nil )
-    {
-		_contentView = [[UIView alloc] initWithFrame: self.bounds];
-        _contentView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
-        _contentView.autoresizesSubviews = YES;
-        self.autoresizesSubviews = YES;
-        _contentView.backgroundColor = [UIColor whiteColor];
-		[_contentView.layer setValue: [NSNumber numberWithBool: YES] forKey: @"KoboHackInterestingLayer"];
-        [self addSubview: _contentView];
-    }
+	if ( _contentView == nil ) {
+	
+		UIView *addedView = [[UIView alloc] initWithFrame: self.bounds];
+		addedView.backgroundColor = [UIColor whiteColor];
+		
+		[self setContentView:addedView];
+		
+	}
 	return ( _contentView );
+}
+
+- (void) setContentView:(UIView *)newContentView {
+
+	self.autoresizesSubviews = YES;
+
+	[_contentView removeFromSuperview];
+	[_contentView release];
+
+	_contentView = [newContentView retain];
+	_contentView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+	_contentView.autoresizesSubviews = YES;
+	[_contentView.layer setValue: [NSNumber numberWithBool: YES] forKey: @"KoboHackInterestingLayer"];
+
+	[self addSubview: _contentView];
+
 }
 
 - (CALayer *) glowSelectionLayer

--- a/Classes/AQGridViewUpdateInfo.m
+++ b/Classes/AQGridViewUpdateInfo.m
@@ -258,7 +258,7 @@
 					{
 						if ( _oldToNewIndexMap[i] != NSNotFound )
                         {
-                            if ( i < _oldGridData.numberOfItems-1 )
+                            if ( i <= _oldGridData.numberOfItems-1 )
                             {
                                 _oldToNewIndexMap[i] = _oldToNewIndexMap[i]-1;
                                 TEST_GUARD(_oldToNewIndexMap, _oldGridData.numberOfItems);

--- a/Classes/AQGridViewUpdateInfo.m
+++ b/Classes/AQGridViewUpdateInfo.m
@@ -273,10 +273,10 @@
 				else if ( item.index > item.newIndex )
 				{
 					// moving backwards-- shuffle middle items up one place
-					for ( NSInteger i = MIN(item.index-1, (_oldGridData.numberOfItems-1)); i >= item.newIndex; i-- )
+					for ( NSInteger i = MIN(item.index-1, (_oldGridData.numberOfItems-1)); (i >= item.newIndex && i >= 0); i-- )
 					{
 						if ( _oldToNewIndexMap[i] != NSNotFound )
-                        {
+		{
                             if ( i >= 0 )
                             {
                                 _oldToNewIndexMap[i] = _oldToNewIndexMap[i]+1;


### PR DESCRIPTION
As title — these commits allow the cell’s background and content views to be configurable via Interface Builder.  Also un-fixes a circumstance, where an exception is silently eaten.

The exception is, empirically, thrown when a cell returns nil for its reuse identifier.
