### PR TITLE
Fixed Issue 53 with the smallest patch ever.

### DIFF
--- a/Classes/AQGridViewCell.m
+++ b/Classes/AQGridViewCell.m
@@ -301,6 +301,7 @@
 {
 	if ( (_cellFlags.usingDefaultSelectedBackgroundView == 1) && (_selectedBackgroundView == nil) )
 	{
+		NSString * imageName = @"AQGridSelection.png";        
 #ifdef BUILTIN_IMAGES
 		unsigned char * pngBytes = AQGridSelection_png;
 		NSUInteger pngLength = AQGridSelection_png_len;
@@ -330,7 +331,6 @@
 		NSData *pngData = [NSData dataWithBytesNoCopy: pngBytes length: pngLength freeWhenDone: NO];
 		_selectedBackgroundView = [[UIImageView alloc] initWithImage: [UIImage imageWithData: pngData]];
 #else
-		NSString * imageName = @"AQGridSelection.png";
 		switch ( _cellFlags.selectionStyle )
 		{
 			case AQGridViewCellSelectionStyleBlue:


### PR DESCRIPTION
If you clone master (2d86535eae21a3c28119752a90dfcaff1b22e82e) and build, you will get 4 errors:

```
/.../AQGridView/Classes/AQGridViewCell.m:314:5: error: use of undeclared identifier 'imageName'
                             imageName = @"AQGridSelectionGray.png";
                             ^
/.../AQGridView/Classes/AQGridViewCell.m:318:5: error: use of undeclared identifier 'imageName'
                             imageName = @"AQGridSelectionGrayBlue.png";
                             ^
/.../AQGridView/Classes/AQGridViewCell.m:322:5: error: use of undeclared identifier 'imageName'
                             imageName = @"AQGridSelectionGreen.png";
                             ^
/.../AQGridView/Classes/AQGridViewCell.m:326:5: error: use of undeclared identifier 'imageName'
                             imageName = @"AQGridSelectionRed.png";
                             ^
4 errors generated.
```
