### PR TITLE
NSLog with DLog, which is compiled out of code without DEBUG symbol defined

### DIFF
--- a/AQGridView.xcodeproj/project.pbxproj
+++ b/AQGridView.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -213,7 +213,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "AQGridView" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -318,11 +318,17 @@
 				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNKNOWN_PRAGMAS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -333,11 +339,17 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNKNOWN_PRAGMAS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Classes/AQGridView.h
+++ b/Classes/AQGridView.h
@@ -37,6 +37,18 @@
 #import <UIKit/UIKit.h>
 #import "AQGridViewCell.h"
 
+// Courtesy of http://iphoneincubator.com/blog/debugging/the-evolution-of-a-replacement-for-DLog
+// DLog is almost a drop-in replacement for DLog
+// DLog();
+// DLog(@"here");
+// DLog(@"value: %d", x);
+// Unfortunately this doesn't work DLog(aStringVariable); you have to do this instead DLog(@"%@", aStringVariable);
+#ifdef DEBUG
+#	define DLog(fmt, ...) DLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);
+#else
+#	define DLog(...)
+#endif
+
 typedef enum {
 	AQGridViewScrollPositionNone,
 	AQGridViewScrollPositionTop,

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -474,7 +474,7 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 		}
 	}
 
-	//NSLog( @"Resetting offset from %@ to %@", NSStringFromCGPoint(oldOffset), NSStringFromCGPoint(offset) );
+	//DLog( @"Resetting offset from %@ to %@", NSStringFromCGPoint(oldOffset), NSStringFromCGPoint(offset) );
 	self.contentOffset = offset;
 }
 
@@ -619,7 +619,7 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 		}
 		else if ( [reuseSet member: cell] == cell )
 		{
-			NSLog( @"Warning: tried to add duplicate gridview cell" );
+			DLog( @"Warning: tried to add duplicate gridview cell" );
 			continue;
 		}
 
@@ -1503,7 +1503,7 @@ passToSuper:
 	// updated: if we're adding it to our visibleCells collection, really it should be in the gridview.
 	if ( cell.superview == nil )
 	{
-		NSLog( @"Visible cell not in gridview - adding" );
+		DLog( @"Visible cell not in gridview - adding" );
 		if ( _backgroundView.superview == self )
 			[self insertSubview: cell aboveSubview: _backgroundView];
 		else
@@ -1594,11 +1594,11 @@ passToSuper:
 
 				// get an index set for everything being removed relative to items' locations within the visible cell list
 				[shifted shiftIndexesStartingAtIndex: [removedIndices firstIndex] by: 0 - (NSInteger)_visibleIndices.location];
-				//NSLog( @"Removed indices relative to visible cell list: %@", shifted );
+				//DLog( @"Removed indices relative to visible cell list: %@", shifted );
 
 				NSUInteger index=[shifted firstIndex];
 				while(index != NSNotFound){
-					//NSLog(@"%i >= %i ?", index, [_visibleCells count]);
+					//DLog(@"%i >= %i ?", index, [_visibleCells count]);
 					if (index >= [_visibleCells count]) {
 						[shifted removeIndex:index];
 					}
@@ -1610,7 +1610,7 @@ passToSuper:
 
 				// remove them from the visible list
 				[_visibleCells removeObjectsInArray: removedCells];
-				//NSLog( @"After removals, visible cells count = %lu", (unsigned long)[_visibleCells count] );
+				//DLog( @"After removals, visible cells count = %lu", (unsigned long)[_visibleCells count] );
 
 				// don't need this any more
 				[shifted release]; shifted = nil;
@@ -1695,7 +1695,7 @@ passToSuper:
 
 			if ( [_visibleCells count] > [newVisibleIndices count] )
 			{
-				//NSLog( @"Have to prune visible cell list, I've still got extra cells in there!" );
+				//DLog( @"Have to prune visible cell list, I've still got extra cells in there!" );
                 NSMutableIndexSet * animatingDestinationIndices = [[NSMutableIndexSet alloc] init];
                 for ( AQGridViewAnimatorItem * item in _animatingCells )
                 {
@@ -1711,13 +1711,13 @@ passToSuper:
 					if ( [newVisibleIndices containsIndex: cell.displayIndex] == NO &&
                          [animatingDestinationIndices containsIndex: cell.displayIndex] == NO )
 					{
-						NSLog( @"Cell for index %lu is still in visible list, removing...", (unsigned long)cell.displayIndex );
+						DLog( @"Cell for index %lu is still in visible list, removing...", (unsigned long)cell.displayIndex );
 						[cell removeFromSuperview];
 						[toRemove addIndex: i];
 					}
 					else if ( [seen containsIndex: cell.displayIndex] )
 					{
-						NSLog( @"Multiple cells with index %lu found-- removing duplicate...", (unsigned long)cell.displayIndex );
+						DLog( @"Multiple cells with index %lu found-- removing duplicate...", (unsigned long)cell.displayIndex );
 						[cell removeFromSuperview];
 						[toRemove addIndex: i];
 					}
@@ -1733,7 +1733,7 @@ passToSuper:
 
 			if ( [_visibleCells count] < [newVisibleIndices count] )
 			{
-				NSLog( @"Visible cell list is missing some items!" );
+				DLog( @"Visible cell list is missing some items!" );
 
 				NSMutableIndexSet * visibleSet = [[NSMutableIndexSet alloc] init];
 				for ( AQGridViewCell * cell in _visibleCells )
@@ -1745,7 +1745,7 @@ passToSuper:
 				[missingSet removeIndexes: visibleSet];
 				[visibleSet release];
 
-				NSLog( @"Got %lu missing indices", (unsigned long)[missingSet count] );
+				DLog( @"Got %lu missing indices", (unsigned long)[missingSet count] );
 
 				NSUInteger idx = [missingSet firstIndex];
 				while ( idx != NSNotFound )
@@ -1803,7 +1803,7 @@ passToSuper:
 		if ( ([_visibleCells count] != [newVisibleIndices count]) ||
 			([newVisibleIndices countOfIndexesInRange: _visibleIndices] != _visibleIndices.length) )
 		{
-			//NSLog( @"\n\n----------BEGIN CELL UPDATES----------" );
+			//DLog( @"\n\n----------BEGIN CELL UPDATES----------" );
 
 			// something has changed. Compute intersections and remove/add cells as required
 			NSIndexSet * currentVisibleIndices = [NSIndexSet indexSetWithIndexesInRange: _visibleIndices];
@@ -1824,8 +1824,8 @@ passToSuper:
 				insertedIndices = [newVisibleIndices aq_indexesOutsideIndexSet: currentVisibleIndices];
 			}
 
-			//NSLog( @"Removing indices: %@, inserting indices: %@", removedIndices, insertedIndices );
-			//NSLog( @"Visible cells count = %lu", (unsigned long)[_visibleCells count] );
+			//DLog( @"Removing indices: %@, inserting indices: %@", removedIndices, insertedIndices );
+			//DLog( @"Visible cells count = %lu", (unsigned long)[_visibleCells count] );
 
 			if ( ([removedIndices count] != 0) || ([insertedIndices count] != 0) )
 			{
@@ -1835,14 +1835,14 @@ passToSuper:
 
 					// get an index set for everything being removed relative to items' locations within the visible cell list
 					[shifted shiftIndexesStartingAtIndex: [removedIndices firstIndex] by: 0 - (NSInteger)_visibleIndices.location];
-					//NSLog( @"Removed indices relative to visible cell list: %@", shifted );
+					//DLog( @"Removed indices relative to visible cell list: %@", shifted );
 
 					// pull out the cells for manipulation
 					NSArray * removedCells = [_visibleCells objectsAtIndexes: shifted];
 
 					// remove them from the visible list
 					[_visibleCells removeObjectsAtIndexes: shifted];
-					//NSLog( @"After removals, visible cells count = %lu", (unsigned long)[_visibleCells count] );
+					//DLog( @"After removals, visible cells count = %lu", (unsigned long)[_visibleCells count] );
 
 					// don't need this any more
 					[shifted release]; shifted = nil;
@@ -1857,7 +1857,7 @@ passToSuper:
 						[mutable release];
 					}
 
-					//NSLog( @"Removing %lu cells from screen", (unsigned long)[removedCells count] );
+					//DLog( @"Removing %lu cells from screen", (unsigned long)[removedCells count] );
 					[removedCells makeObjectsPerformSelector: @selector(removeFromSuperview)];
 
 					// put them into the cell reuse queue
@@ -1868,8 +1868,8 @@ passToSuper:
 				{
 					// now we do the insertions
 					NSUInteger first = [newVisibleIndices firstIndex];
-					NSLog( @"New starting index = %lu", (unsigned long)first );
-					NSLog( @"Visible cell count = %lu", (unsigned long)[_visibleCells count] );
+					DLog( @"New starting index = %lu", (unsigned long)first );
+					DLog( @"Visible cell count = %lu", (unsigned long)[_visibleCells count] );
 
 					// if there are cells being animated into place, skip them-- the animation has them already
 					if ( self.animatingCells.count != 0 )
@@ -1891,7 +1891,7 @@ passToSuper:
 						AQGridViewCell * cell = [self createPreparedCellForIndex: idx];
 						[self delegateWillDisplayCell: cell atIndex: idx];
 
-						NSLog( @"Inserting cell for index %lu at visible list index %lu", (unsigned long)idx, (unsigned long)(idx - first) );
+						DLog( @"Inserting cell for index %lu at visible list index %lu", (unsigned long)idx, (unsigned long)(idx - first) );
 						[_visibleCells insertObject: cell atIndex: idx-first];
 
 						idx = [insertedIndices indexGreaterThanIndex: idx];
@@ -1913,7 +1913,7 @@ passToSuper:
 
 				if ( [removeVisibleCells count] != 0 )
 				{
-					NSLog( @"Missed some cells which need to be pruned from the visible cell list: %@", removeVisibleCells );
+					DLog( @"Missed some cells which need to be pruned from the visible cell list: %@", removeVisibleCells );
 					[_visibleCells removeObjectsAtIndexes: removeVisibleCells];
 				}
 
@@ -1938,7 +1938,7 @@ passToSuper:
 				[self layoutCellsInVisibleCellRange: NSMakeRange(0, [_visibleCells count])];
 			}
 
-			//NSLog( @"----------END CELL UPDATES----------\n\n" );
+			//DLog( @"----------END CELL UPDATES----------\n\n" );
 		}
 	}
 	@finally
@@ -1964,7 +1964,7 @@ passToSuper:
 	NSUInteger beforeTest = (_visibleIndices.location == 0 ? NSNotFound : _visibleIndices.location - 1);
 	NSUInteger afterTest = MIN(_visibleIndices.location+_visibleIndices.length, _gridData.numberOfItems);
 
-	//NSLog( @"New Visible Indices = %@, _visibleIndices = %@", newVisibleIndices, NSStringFromRange(_visibleIndices) );
+	//DLog( @"New Visible Indices = %@, _visibleIndices = %@", newVisibleIndices, NSStringFromRange(_visibleIndices) );
 
 	// do we need to remove anything?
 	if ( [newVisibleIndices countOfIndexesInRange: _visibleIndices] < _visibleIndices.length )
@@ -1986,7 +1986,7 @@ passToSuper:
 			else
 				arrayRange = NSMakeRange([_visibleCells count] - numToRemove, numToRemove);
 
-			//NSLog( @"Removing cells in visible range: %@", NSStringFromRange(arrayRange) );
+			//DLog( @"Removing cells in visible range: %@", NSStringFromRange(arrayRange) );
 
 			// grab the removed cells (retains them)
 			NSMutableArray * removedCells = [[[_visibleCells subarrayWithRange: arrayRange] mutableCopy] autorelease];
@@ -2242,7 +2242,7 @@ passToSuper:
 		cell.separatorEdge = edge;
 	}
 
-    //NSLog( @"Displaying cell at index %lu", (unsigned long) index );
+    //DLog( @"Displaying cell at index %lu", (unsigned long) index );
 
 	if ( _flags.delegateWillDisplayCell == 0 )
 		return;

--- a/Classes/AQGridViewUpdateInfo.m
+++ b/Classes/AQGridViewUpdateInfo.m
@@ -731,7 +731,7 @@
 	NSIndexSet * oldVisibleIndices = [_oldGridData indicesOfCellsInRect: contentRect];
 	
     // The line below is commented because it produces too many logs
-	// NSLog( @"Updating from original content rect %@", NSStringFromCGRect(contentRect) );
+	// DLog( @"Updating from original content rect %@", NSStringFromCGRect(contentRect) );
 	
 	if ( (isVertical) && (maxY > gridSize.height) )
 	{
@@ -761,7 +761,7 @@
 	}
 	
     // The line below is fixed because it produces too many logs
-	//NSLog( @"Updated content rect: %@", NSStringFromCGRect(contentRect) );
+	//DLog( @"Updated content rect: %@", NSStringFromCGRect(contentRect) );
 	NSIndexSet * newVisibleIndices = [_newGridData indicesOfCellsInRect: contentRect];
 	
 	NSMutableSet * newVisibleCells = [[NSMutableSet alloc] initWithSet: _gridView.animatingCells];
@@ -836,7 +836,7 @@
 		// animate it into its new location
 		CGRect frame = [_gridView fixCellFrame: cell.frame forGridRect: [_newGridData cellRectAtIndex: newIndex]];
 		//if ( CGRectEqualToRect(frame, cell.frame) == NO )
-		//	NSLog( @"Moving frame from %@ to %@", NSStringFromCGRect(cell.frame), NSStringFromCGRect(frame) );
+		//	DLog( @"Moving frame from %@ to %@", NSStringFromCGRect(cell.frame), NSStringFromCGRect(frame) );
 		cell.frame = frame;
 		
 		// tell the grid view's delegate about it

--- a/Examples/SpringBoard/Classes/SpringBoardViewController.m
+++ b/Examples/SpringBoard/Classes/SpringBoardViewController.m
@@ -131,14 +131,14 @@
     if ( UIInterfaceOrientationIsPortrait(toInterfaceOrientation) )
     {
         // width will be 768, which divides by four nicely already
-        NSLog( @"Setting left+right content insets to zero" );
+        DLog( @"Setting left+right content insets to zero" );
         _gridView.leftContentInset = 0.0;
         _gridView.rightContentInset = 0.0;
     }
     else
     {
         // width will be 1024, so subtract a little to get a width divisible by five
-        NSLog( @"Setting left+right content insets to 2.0" );
+        DLog( @"Setting left+right content insets to 2.0" );
         _gridView.leftContentInset = 2.0;
         _gridView.rightContentInset = 2.0;
     }
@@ -231,7 +231,7 @@
             CGRect f = _draggingCell.frame;
             f.origin.x = r.origin.x + floorf((r.size.width - f.size.width) * 0.5);
             f.origin.y = r.origin.y + floorf((r.size.height - f.size.height) * 0.5) - _gridView.contentOffset.y;
-            NSLog( @"Gesture ended-- moving to %@", NSStringFromCGRect(f) );
+            DLog( @"Gesture ended-- moving to %@", NSStringFromCGRect(f) );
             _draggingCell.frame = f;
             
             _draggingCell.transform = CGAffineTransformIdentity;
@@ -298,7 +298,7 @@
 			
             if ( index != _emptyCellIndex )
             {
-                NSLog( @"Moving empty cell from %u to %u", _emptyCellIndex, index );
+                DLog( @"Moving empty cell from %u to %u", _emptyCellIndex, index );
                 
                 // batch the movements
                 [_gridView beginUpdates];
@@ -308,7 +308,7 @@
                 {
                     for ( NSUInteger i = index; i < _emptyCellIndex; i++ )
                     {
-                        NSLog( @"Moving %u to %u", i, i+1 );
+                        DLog( @"Moving %u to %u", i, i+1 );
                         [_gridView moveItemAtIndex: i toIndex: i+1 withAnimation: AQGridViewItemAnimationFade];
                     }
                 }
@@ -316,7 +316,7 @@
                 {
                     for ( NSUInteger i = index; i > _emptyCellIndex; i-- )
                     {
-                        NSLog( @"Moving %u to %u", i, i-1 );
+                        DLog( @"Moving %u to %u", i, i-1 );
                         [_gridView moveItemAtIndex: i toIndex: i-1 withAnimation: AQGridViewItemAnimationFade];
                     }
                 }
@@ -363,7 +363,7 @@
     
     if ( index == _emptyCellIndex )
     {
-        NSLog( @"Loading empty cell at index %u", index );
+        DLog( @"Loading empty cell at index %u", index );
         AQGridViewCell * hiddenCell = [gridView dequeueReusableCellWithIdentifier: EmptyIdentifier];
         if ( hiddenCell == nil )
         {


### PR DESCRIPTION
Hi,

I replaced all calls to NSLog with DLog, which is compiled out of code without the DEBUG symbol. I've been using this in my own projects for a while.

Also updated project build settings to be a little more restrictive and removed the old build setting PREBINDING.

Thanks, Dave
