### PR TITLE
Fix content sizing bug for horizontal grid views

### DIFF
--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -543,7 +543,7 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	        newSize.height = minimumHeight;
 	}
 
-	newSize.height = fmax(newSize.height, self.frame.size.height+1);
+	newSize.height = fmax(newSize.height, self.frame.size.height);
 
 	CGSize oldSize = self.contentSize;
 	[super setContentSize: newSize];


### PR DESCRIPTION
Remove the one-pixel expansion of the maximum content size. This was causing horizontally-oriented scroll views to always bounce vertically (because the content size height was always +1px)
