### PR TITLE
Issue #74 "contentSizeGrowsToFillBounds is not working"

### DIFF
--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -522,7 +522,8 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	        newSize.height = minimumHeight;
 	}
 
-	newSize.height = fmax(newSize.height, self.frame.size.height+1);
+    if (_flags.contentSizeFillsBounds == 1)
+    	newSize.height = fmax(newSize.height, self.frame.size.height+1);
 
 	CGSize oldSize = self.contentSize;
 	[super setContentSize: newSize];

--- a/Classes/AQGridViewData.m
+++ b/Classes/AQGridViewData.m
@@ -162,7 +162,7 @@
 		numRows++;
 	
 	CGFloat height = ( ((CGFloat)ceilf((CGFloat)numRows * _actualCellSize.height)) + _topPadding + _bottomPadding );
-	if (height < _gridView.bounds.size.height)
+	if (height < _gridView.bounds.size.height && _gridView.contentSizeGrowsToFillBounds)
 		height = _gridView.bounds.size.height;
 	
 	return ( CGSizeMake(((CGFloat)ceilf(_actualCellSize.width * numPerRow)) + _leftPadding + _rightPadding, height) );


### PR DESCRIPTION
Needed the AQGridView actual contentSize without expanding to the view's bounds (height), so I made it honor the contentSizeGrowsToFillBounds property. Appears to have been detached at some point in the past.
