### PR TITLE
layout all cells after HeaderView's height was changed

### DIFF
--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -654,6 +654,15 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	if ( (_flags.needsReload == 1) && (_animationCount == 0) && (_reloadingSuspendedCount == 0) )
 		[self reloadData];
 
+    if (_headerView)
+    {
+        if (_gridData.topPadding != _headerView.frame.size.height)
+        {
+            _flags.allCellsNeedLayout = 1;
+            _gridData.topPadding = _headerView.frame.size.height;
+        }
+    }
+    
 	if ( (_reloadingSuspendedCount == 0) && (!CGRectIsEmpty([self gridViewVisibleBounds])) )
 	{
         [self updateVisibleGridCellsNow];

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -89,6 +89,7 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 @interface AQGridView ()
 @property (nonatomic, copy) NSIndexSet * animatingIndices;
 - (void) cellUpdateAnimationStopped: (NSString *) animationID finished: (BOOL) finished context: (void *) context;
+- (void) handleGridViewBoundsChanged: (CGRect) oldBounds toNewBounds: (CGRect) bounds;
 @end
 
 
@@ -357,6 +358,9 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	[_headerView removeFromSuperview];
 
 	_headerView = newHeaderView;
+    
+    CGFloat oldHeight = _gridData.topPadding;
+
 	if ( _headerView == nil )
 	{
 		_gridData.topPadding = 0.0;
@@ -367,6 +371,10 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 		_gridData.topPadding = _headerView.frame.size.height;
 	}
 
+    if ( _gridData.topPadding != oldHeight ) 
+    {
+        [self handleGridViewBoundsChanged:self.bounds toNewBounds:self.bounds];
+    }
 	[self setNeedsLayout];
 }
 
@@ -383,6 +391,8 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	[_footerView removeFromSuperview];
 
 	_footerView = newFooterView;
+    
+    CGFloat oldHeight = _gridData.bottomPadding;
 	if ( _footerView == nil )
 	{
 		_gridData.bottomPadding = 0.0;
@@ -393,6 +403,9 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 		_gridData.bottomPadding = _footerView.frame.size.height;
 	}
 
+    if ( _gridData.bottomPadding != oldHeight ) {
+        [self handleGridViewBoundsChanged:self.bounds toNewBounds:self.bounds];
+    }
 	[self setNeedsLayout];
 }
 
@@ -654,13 +667,12 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	if ( (_flags.needsReload == 1) && (_animationCount == 0) && (_reloadingSuspendedCount == 0) )
 		[self reloadData];
 
-    if (_headerView)
+    if ( (_headerView && _gridData.topPadding != _headerView.frame.size.height ) || 
+         (_footerView && _gridData.bottomPadding != _footerView.frame.size.height) )
     {
-        if (_gridData.topPadding != _headerView.frame.size.height)
-        {
-            _flags.allCellsNeedLayout = 1;
-            _gridData.topPadding = _headerView.frame.size.height;
-        }
+        _gridData.topPadding = _headerView.frame.size.height;
+        _gridData.bottomPadding = _footerView.frame.size.height;
+        [self handleGridViewBoundsChanged:self.bounds toNewBounds:self.bounds];
     }
     
 	if ( (_reloadingSuspendedCount == 0) && (!CGRectIsEmpty([self gridViewVisibleBounds])) )


### PR DESCRIPTION
Some times the HeaderView's height will be changed, after that I will call [gridView setNeedsLayout] to relayout.

This commit fixed the problem that the layoutSubviews method did not notice the height of headView changed.
