### PR TITLE
Setting SelectionStyleNone currently breaks rotation

### DIFF
--- a/Classes/AQGridViewCell.m
+++ b/Classes/AQGridViewCell.m
@@ -437,7 +437,7 @@
 	if ( _cellFlags.selectionStyle == AQGridViewCellSelectionStyleNone )
 	{
 		_cellFlags.highlighted = (value ? 1 : 0);
-		return;
+		//return;
 	}
 	
 	_cellFlags.becomingHighlighted = (value ? 1 : 0);


### PR DESCRIPTION
To reproduce set line 240 of ImageDemoViewController to

```
plainCell.selectionStyle = AQGridViewCellSelectionStyleNone;
```

Then rotate from landscape to portrait orientation.

I have found a fix that seems to work just fine (making selectionStyleNone work int the same way as the default and not breaking rotation), but maybe there is a more proper way of doing this?
