### PR TITLE
Fix for small images in image demo

### DIFF
--- a/Examples/ImageDemo/Classes/ImageDemoGridViewCell.m
+++ b/Examples/ImageDemo/Classes/ImageDemoGridViewCell.m
@@ -80,6 +80,7 @@
     if ( (imageSize.width <= bounds.size.width) &&
          (imageSize.height <= bounds.size.height) )
     {
+        _imageView.frame = CGRectMake(0.0, 0.0, imageSize.width, imageSize.height);
         return;
     }
     


### PR DESCRIPTION
Was having trouble with the image demo code when I used images that were smaller than the size of the cells. Adding this line fixed it for me.
