### PR TITLE
Recalculate contentOffset for device rotation

### DIFF
--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -459,8 +459,15 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 
 - (void) handleGridViewBoundsChanged: (CGRect) oldBounds toNewBounds: (CGRect) bounds
 {
+    CGPoint oldOffset = self.contentOffset;
 	CGSize oldGridSize = [_gridData sizeForEntireGrid];
 	BOOL wasAtBottom = ((oldGridSize.height != 0.0) && (CGRectGetMaxY(oldBounds) == oldGridSize.height));
+
+    // cell height may change on rotation
+    if ( _flags.dataSourceGridCellSize == 1 )
+	{
+        [_gridData setDesiredCellSize: [_dataSource portraitGridCellSizeForGridView: self]];
+	}
 
 	[_gridData gridViewDidChangeBoundsSize: bounds.size];
     _flags.numColumns = [_gridData numberOfItemsPerRow];
@@ -478,6 +485,19 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 			self.contentOffset = contentRect.origin;
 		}
 	}
+    else if (!wasAtBottom && !CGPointEqualToPoint(oldBounds.origin, CGPointZero) && !CGSizeEqualToSize(oldGridSize, CGSizeZero))
+    {
+        // If not at the bottom or top (they are handled above and in updateContentRectWithOldMaxLocation)
+        // and we have data to work with (sometimes we can start with the oldSize == 0),
+        // constentOffset.y needs to be reset to be proportional to the new height. Then snap it to the nearest cell boundry.
+        
+        CGFloat proportionalY = newGridSize.height * (oldOffset.y / oldGridSize.height);
+        CGRect cellRect = [_gridData cellRectForPoint:CGPointMake(self.contentOffset.x, proportionalY)];
+        CGFloat newY = (proportionalY < (cellRect.origin.y + (cellRect.size.height / 2.0f))) ?
+        cellRect.origin.y : cellRect.origin.y + cellRect.size.height;
+        self.contentOffset = CGPointMake(self.contentOffset.x, newY);
+    }
+
 
 	[self updateVisibleGridCellsNow];
 	_flags.allCellsNeedLayout = 1;


### PR DESCRIPTION
On very large tables with different layouts in portrait/landscape like 3x4/4x3 the total grid height can be very different so its necessary to change the contentOffset proportionally. This keeps the current cells in view (as much as possible). Before making any calculations the cell size needs to be fetched to handle cases when its height differs between portrait and landscape.
