### PR TITLE
Handle bounds change on height change

### DIFF
--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -459,8 +459,15 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 
 - (void) handleGridViewBoundsChanged: (CGRect) oldBounds toNewBounds: (CGRect) bounds
 {
+    CGPoint oldOffset = self.contentOffset;
 	CGSize oldGridSize = [_gridData sizeForEntireGrid];
 	BOOL wasAtBottom = ((oldGridSize.height != 0.0) && (CGRectGetMaxY(oldBounds) == oldGridSize.height));
+
+    // cell height may change on rotation
+    if ( _flags.dataSourceGridCellSize == 1 )
+	{
+        [_gridData setDesiredCellSize: [_dataSource portraitGridCellSizeForGridView: self]];
+	}
 
 	[_gridData gridViewDidChangeBoundsSize: bounds.size];
     _flags.numColumns = [_gridData numberOfItemsPerRow];
@@ -478,6 +485,19 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 			self.contentOffset = contentRect.origin;
 		}
 	}
+    else if (!wasAtBottom && !CGPointEqualToPoint(oldBounds.origin, CGPointZero) && !CGSizeEqualToSize(oldGridSize, CGSizeZero))
+    {
+        // If not at the bottom or top (they are handled above and in updateContentRectWithOldMaxLocation)
+        // and we have data to work with (sometimes we can start with the oldSize == 0),
+        // constentOffset.y needs to be reset to be proportional to the new height. Then snap it to the nearest cell boundry.
+        
+        CGFloat proportionalY = newGridSize.height * (oldOffset.y / oldGridSize.height);
+        CGRect cellRect = [_gridData cellRectForPoint:CGPointMake(self.contentOffset.x, proportionalY)];
+        CGFloat newY = (proportionalY < (cellRect.origin.y + (cellRect.size.height / 2.0f))) ?
+        cellRect.origin.y : cellRect.origin.y + cellRect.size.height;
+        self.contentOffset = CGPointMake(self.contentOffset.x, newY);
+    }
+
 
 	[self updateVisibleGridCellsNow];
 	_flags.allCellsNeedLayout = 1;

--- a/Classes/AQGridView.m
+++ b/Classes/AQGridView.m
@@ -565,7 +565,7 @@ NSString * const AQGridViewSelectionDidChangeNotification = @"AQGridViewSelectio
 	[super setFrame: newFrame];
 	CGRect newBounds = self.bounds;
 
-	if ( newBounds.size.width != oldBounds.size.width )
+    if ( !CGSizeEqualToSize(newBounds.size, oldBounds.size) )
 		[self handleGridViewBoundsChanged: oldBounds toNewBounds: newBounds];
 }
 


### PR DESCRIPTION
The setFrame method of AQGridView used to only call handleGridViewBoundsChanged if the bounds width actually changes. (This to prevent unnecessary work if setFrame is called again with same bounds I suppose) But there are cases when the height will change and the grid content height needs to be recalculated appropriately. This patch detects a change to height as well so that happens.

In my case a large 3x4 (portrait) and 4x3 (landscape) grid table is displayed in a view with a navigation bar. A cell is selected causing another view to be pushed on the stack. That view is rotated and we return to the grid. SetFrame is called twice, the 1st time it resets the frame height & width to the new orientation, BUT without accounting for the navigation bar. The 2nd time it resets the frame to account for the bar, but the width is the same. The old logic bypassed the logic I added to the parent branch that recalculates the current content offset proportionally to the height so the content stays in view. So the 1st time setFrame is called the cells are all calculated to be a little taller (to fit) and depending on the size of the table and how far down you scrolled results in the view showing cells that are a number of rows away from those shown before the rotation.
