### PR TITLE
Fix warnings in Xcode 4.5

### DIFF
--- a/Classes/AQGridViewCell.m
+++ b/Classes/AQGridViewCell.m
@@ -98,6 +98,7 @@
 {
 	if ( _selectionColorInfo != NULL )
 		CFRelease( _selectionColorInfo );
+	[super dealloc];
 }
 
 - (NSComparisonResult) compareOriginAgainstCell: (AQGridViewCell *) otherCell

--- a/Classes/AQGridViewUpdateInfo.m
+++ b/Classes/AQGridViewUpdateInfo.m
@@ -70,6 +70,7 @@
 		free( _oldToNewIndexMap );
 	if ( _newToOldIndexMap != NULL )
 		free( _newToOldIndexMap );
+	[super dealloc];
 }
 
 - (NSMutableArray *) updateItemArrayForAction: (AQGridViewUpdateAction) action


### PR DESCRIPTION
Added 2 missing dealloc calls to suppress warnings.

The missing deallocs were causing a `Method possibly missing a [super dealloc] call` warning to be displayed in Xcode 4.5.
